### PR TITLE
Make the update checker check for LibreBounce updates, not LiquidBounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Common Changelog](https://common-changelog.org), which i
 
 ### Fixed
 
-- Fix the update checker not working ([#248](https://github.com/Level/level/issues/248)) (thatonecoder)
+- Fix the update checker not working ([#8](https://github.com/LibreBounce/LibreBounce/pull/8)) (thatonecoder)
 - Fix the `RenderBoxOnSwingFail` option (and some of its adjacent settings) in KillAura not being subjective, NOT DONE YET (thatonecoder)
 
 ## [0.1.0] - 2025-06-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Common Changelog](https://common-changelog.org), which i
 
 ### Fixed
 
+- Fix the update checker not working ([#248](https://github.com/Level/level/issues/248)) (thatonecoder)
 - Fix the `RenderBoxOnSwingFail` option (and some of its adjacent settings) in KillAura not being subjective, NOT DONE YET (thatonecoder)
 
 ## [0.1.0] - 2025-06-09

--- a/build.gradle
+++ b/build.gradle
@@ -53,15 +53,15 @@ dependencies {
 
     annotationProcessor("org.spongepowered:mixin:0.7.11-SNAPSHOT")
 
-    implementation "com.jagrosh:DiscordIPC:0.4"
+    implementation("com.jagrosh:DiscordIPC:0.4")
 
     implementation("com.github.CCBlueX:Elixir:1.2.6") {
         exclude module: "kotlin-stdlib"
         exclude module: "authlib"
     }
 
-    implementation 'com.github.TheAltening:TheAltening4j:d0771f42d3'
-    implementation 'com.github.TheAltening:API-Java-AuthLib:63a9702615'
+    implementation("com.github.TheAltening:TheAltening4j:d0771f42d3")
+    implementation("com.github.TheAltening:API-Java-AuthLib:63a9702615")
 
     implementation("org.knowm.xchart:xchart:3.8.8")
 
@@ -71,12 +71,15 @@ dependencies {
     }
 
     // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version")
+
+    // Update Checker
+    implementation("com.vdurmont:semver4j:3.1.0")
 
     // Swing LookAndFeel
-    implementation "com.formdev:flatlaf:3.5.4"
+    implementation("com.formdev:flatlaf:3.5.4")
 
     implementation fileTree(include: ["*.jar"], dir: "libs")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx3g
 
-mod_version=0.1.0
+mod_version=0.2.0
 maven_group=net.ccbluex
 archives_base_name=liquidbounce
 

--- a/src/main/java/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -78,7 +78,7 @@ object LiquidBounce {
     const val MINECRAFT_VERSION = "1.8.9"
     
     val clientVersionText = gitInfo["git.build.version"]?.toString() ?: "unknown"
-    val clientVersionNumber = clientVersionText.substring(1).toIntOrNull() ?: 0 // version format: "b<VERSION>" on legacy
+    val clientVersionNumber = clientVersionText.substring(1).toIntOrNull() ?: 0 // version format: "v<VERSION>"
     val clientCommit = gitInfo["git.commit.id.abbrev"]?.let { "git-$it" } ?: "unknown"
     val clientBranch = gitInfo["git.branch"]?.toString() ?: "unknown"
 

--- a/src/main/java/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -86,7 +86,7 @@ object LiquidBounce {
      * Defines if the client is in development mode.
      * This will enable update checking on commit time instead of regular legacy versioning.
      */
-    const val IN_DEV = false
+    const val IN_DEV = true
 
     val clientTitle = CLIENT_NAME + clientVersionText + " " + clientCommit + " | " + MINECRAFT_VERSION + if (IN_DEV) " | DEVELOPMENT BUILD" else ""
 

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -69,7 +69,7 @@ object ClientApi {
         val url = "$GITHUB_API_ENDPOINT/commits/$branch"
         client.get(url).use { response ->
             if (!response.isSuccessful) error("Request failed: ${response.code}")
-            val body = response.body?.string() ?: return null
+            val body = response.body?.string() // ?: return null
             val gson = Gson()
             val json = gson.fromJson(body, JsonObject::class.java)
             val dateString = json

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -9,7 +9,8 @@ import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
-import org.json.JSONObject
+import com.google.gson.Gson
+import com.google.gson.JsonObject
 import java.util.*
 import java.util.concurrent.TimeUnit
 import java.text.SimpleDateFormat
@@ -66,13 +67,15 @@ object ClientApi {
 
     fun getNewestBuildDate(branch: String = HARD_CODED_BRANCH): Date? {
         val url = "$GITHUB_API_ENDPOINT/commits/$branch"
-        val request = Request.Builder().url(url).build()
         client.get(url).use { response ->
             if (!response.isSuccessful) error("Request failed: ${response.code}")
-            val json = JSONObject(response.body?.string() ?: return null)
-            val dateString = json.getJSONObject("commit")
-                .getJSONObject("committer")
-                .getString("date")
+            val body = response.body?.string() ?: return null
+            val gson = Gson()
+            val json = gson.fromJson(body, JsonObject::class.java)
+            val dateString = json
+                .getAsJsonObject("commit")
+                .getAsJsonObject("committer")
+                .get("date").asString
             return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
                 .parse(dateString)
         }

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -9,7 +9,10 @@ import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
+import org.json.JSONObject
+import java.util.*
 import java.util.concurrent.TimeUnit
+import java.text.SimpleDateFormat
 
 private const val HARD_CODED_BRANCH = "main"
 

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -15,6 +15,8 @@ private const val HARD_CODED_BRANCH = "main"
 
 private const val API_V1_ENDPOINT = "https://api.liquidbounce.net/api/v1"
 
+private const val GITHUB_API_ENDPOINT = "https://api.github.com/repos/LibreBounce/LibreBounce"
+
 
 /**
  * Session token
@@ -41,16 +43,18 @@ private val client = OkHttpClient.Builder()
  */
 object ClientApi {
 
+    // Get the latest "stable" release
     fun getNewestRelease(branch: String = HARD_CODED_BRANCH): Build {
-        val url = "https://api.github.com/repos/LibreBounce/LibreBounce/releases/latest"
+        val url = "$GITHUB_API_ENDPOINT/releases/latest"
         client.get(url).use { response ->
             if (!response.isSuccessful) error("Request failed: ${response.code}")
             return response.body.charStream().decodeJson()
         }
     }
 
+    // Get the latest "unstable" build
     fun getNewestBuild(branch: String = HARD_CODED_BRANCH): Build {
-        val url = "https://api.github.com/repos/LibreBounce/LibreBounce/branches/$branch"
+        val url = "$GITHUB_API_ENDPOINT/branches/$branch"
         client.get(url).use { response ->
             if (!response.isSuccessful) error("Request failed: ${response.code}")
             return response.body.charStream().decodeJson()

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -41,7 +41,7 @@ private val client = OkHttpClient.Builder()
  */
 object ClientApi {
 
-    fun getNewestBuild(branch: String = HARD_CODED_BRANCH, release: Boolean = false): Build {
+    fun getNewestBuild(branch: String = HARD_CODED_BRANCH, prerelease: Boolean = true): Build {
         val url = "https://api.github.com/repos/LibreBounce/LibreBounce/releases/latest"
         client.get(url).use { response ->
             if (!response.isSuccessful) error("Request failed: ${response.code}")

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -11,7 +11,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import java.util.concurrent.TimeUnit
 
-private const val HARD_CODED_BRANCH = "legacy"
+private const val HARD_CODED_BRANCH = "main"
 
 private const val API_V1_ENDPOINT = "https://api.liquidbounce.net/api/v1"
 
@@ -41,8 +41,16 @@ private val client = OkHttpClient.Builder()
  */
 object ClientApi {
 
-    fun getNewestBuild(branch: String = HARD_CODED_BRANCH, prerelease: Boolean = true): Build {
+    fun getNewestRelease(branch: String = HARD_CODED_BRANCH): Build {
         val url = "https://api.github.com/repos/LibreBounce/LibreBounce/releases/latest"
+        client.get(url).use { response ->
+            if (!response.isSuccessful) error("Request failed: ${response.code}")
+            return response.body.charStream().decodeJson()
+        }
+    }
+
+    fun getNewestBuild(branch: String = HARD_CODED_BRANCH): Build {
+        val url = "https://api.github.com/repos/LibreBounce/LibreBounce/branches/$branch"
         client.get(url).use { response ->
             if (!response.isSuccessful) error("Request failed: ${response.code}")
             return response.body.charStream().decodeJson()

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -61,6 +61,20 @@ object ClientApi {
         }
     }
 
+    fun getNewestBuildDate(branch: String = HARD_CODED_BRANCH): Date? {
+        val url = "$GITHUB_API_ENDPOINT/commits/$branch"
+        val request = Request.Builder().url(url).build()
+        client.get(url).use { response ->
+            if (!response.isSuccessful) error("Request failed: ${response.code}")
+            val json = JSONObject(response.body?.string() ?: return null)
+            val dateString = json.getJSONObject("commit")
+                .getJSONObject("committer")
+                .getString("date")
+            return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
+                .parse(dateString)
+        }
+    }
+
     fun getSettingsList(branch: String = HARD_CODED_BRANCH): List<AutoSettings> {
         val url = "$API_V1_ENDPOINT/client/$branch/settings"
         client.get(url).use { response ->

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -65,7 +65,7 @@ object ClientApi {
         }
     }
 
-    fun getNewestBuildDate(branch: String = HARD_CODED_BRANCH): Date? {
+    fun getNewestBuildDate(branch: String = HARD_CODED_BRANCH): Date {
         val url = "$GITHUB_API_ENDPOINT/commits/$branch"
         client.get(url).use { response ->
             if (!response.isSuccessful) error("Request failed: ${response.code}")

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientApi.kt
@@ -42,7 +42,7 @@ private val client = OkHttpClient.Builder()
 object ClientApi {
 
     fun getNewestBuild(branch: String = HARD_CODED_BRANCH, release: Boolean = false): Build {
-        val url = "$API_V1_ENDPOINT/version/newest/$branch${if (release) "/release" else "" }"
+        val url = "https://api.github.com/repos/LibreBounce/LibreBounce/releases/latest"
         client.get(url).use { response ->
             if (!response.isSuccessful) error("Request failed: ${response.code}")
             return response.body.charStream().decodeJson()

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -46,7 +46,7 @@ object ClientUpdate {
                 val currentBuildDate =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(gitInfo["git.commit.time"].toString())
 
-                newestBuildDate?.after(currentBuildDate)
+                newestBuildDate.after(currentBuildDate)
             } else {
                 // check if version number is higher than current version number (on release builds only!)
                 val clientSemVersion = Semver(LiquidBounce.clientVersionText, Semver.SemverType.LOOSE)

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -48,10 +48,10 @@ object ClientUpdate {
                 logger.error("Unable to receive update information", exception)
             }.getOrNull() ?: return@AsyncLazy null */
 
-            val newestSemVersion = Semver(newestVersion.tagName, Semver.SemverType.LOOSE)
+            val newestSemVersion = Semver(newestVersion?.tagName, Semver.SemverType.LOOSE)
 
             val isNewer = if (LiquidBounce.IN_DEV) { // check if new build is newer than current build
-                val newestBuildDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestVersion.date)
+                val newestBuildDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestVersion?.date)
                 val currentBuildDate =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(gitInfo["git.commit.time"].toString())
 

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -46,7 +46,7 @@ object ClientUpdate {
                 val currentBuildDate =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(gitInfo["git.commit.time"].toString())
 
-                newestBuildDate.after(currentBuildDate)
+                newestBuildDate?.after(currentBuildDate)
             } else {
                 // check if version number is higher than current version number (on release builds only!)
                 val clientSemVersion = Semver(LiquidBounce.clientVersionText, Semver.SemverType.LOOSE)

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -29,6 +29,7 @@ object ClientUpdate {
         // https://api.liquidbounce.net/api/v1/version/builds/legacy
         try {
             newestVersion = ClientApi.getNewestRelease()
+            newestBuild = ClientApi.getNewestBuild()
         } catch (e: Exception) {
             LOGGER.error("Unable to receive update information", e)
         }
@@ -37,21 +38,15 @@ object ClientUpdate {
     var newestVersion: Build? = null
         private set
 
+    var newestBuild: Build? = null
+        private set
+
     fun hasUpdate(): Boolean {
         try {
-            /* val newestBuild = runCatching {
-                ClientApi.requestNewestBuildEndpoint(
-                    branch = LiquidBounce.clientBranch,
-                    prerelease = LiquidBounce.IN_DEV
-                )
-            }.onFailure { exception ->
-                logger.error("Unable to receive update information", exception)
-            }.getOrNull() ?: return@AsyncLazy null */
-
             val newestSemVersion = Semver(newestVersion?.tagName, Semver.SemverType.LOOSE)
 
             return if (LiquidBounce.IN_DEV) { // check if new build is newer than current build
-                val newestBuildDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestVersion?.date)
+                val newestBuildDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestBuild?.date)
                 val currentBuildDate =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(gitInfo["git.commit.time"].toString())
 

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -28,7 +28,7 @@ object ClientUpdate {
     fun reloadNewestVersion() {
         // https://api.liquidbounce.net/api/v1/version/builds/legacy
         try {
-            newestVersion = ClientApi.getNewestBuild(release = !IN_DEV)
+            newestVersion = ClientApi.getNewestBuild(prerelease = IN_DEV)
         } catch (e: Exception) {
             LOGGER.error("Unable to receive update information", e)
         }
@@ -59,7 +59,7 @@ object ClientUpdate {
         }
     } */
 
-    val update {
+    fun hasUpdate(): Boolean {
         try {
             /* val newestBuild = runCatching {
                 ClientApi.requestNewestBuildEndpoint(
@@ -82,7 +82,7 @@ object ClientUpdate {
                 // check if version number is higher than current version number (on release builds only!)
                 val clientSemVersion = Semver(LiquidBounce.clientVersionText, Semver.SemverType.LOOSE)
 
-                newestBuild.release && newestSemVersion.isGreaterThan(clientSemVersion)
+                !newestBuild.prerelease && newestSemVersion.isGreaterThan(clientSemVersion)
             }
 
             if (isNewer) {

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -50,7 +50,7 @@ object ClientUpdate {
 
             val newestSemVersion = Semver(newestVersion?.tagName, Semver.SemverType.LOOSE)
 
-            val isNewer = if (LiquidBounce.IN_DEV) { // check if new build is newer than current build
+            return if (LiquidBounce.IN_DEV) { // check if new build is newer than current build
                 val newestBuildDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestVersion?.date)
                 val currentBuildDate =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(gitInfo["git.commit.time"].toString())
@@ -61,12 +61,6 @@ object ClientUpdate {
                 val clientSemVersion = Semver(LiquidBounce.clientVersionText, Semver.SemverType.LOOSE)
 
                 newestSemVersion.isGreaterThan(clientSemVersion)
-            }
-
-            if (isNewer) {
-                newestVersion
-            } else {
-                null
             }
         } catch (e: Exception) {
             LOGGER.error("Failed to check for update", e)

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -29,7 +29,6 @@ object ClientUpdate {
         // https://api.liquidbounce.net/api/v1/version/builds/legacy
         try {
             newestVersion = ClientApi.getNewestRelease()
-            newestBuild = ClientApi.getNewestBuild()
         } catch (e: Exception) {
             LOGGER.error("Unable to receive update information", e)
         }
@@ -38,15 +37,12 @@ object ClientUpdate {
     var newestVersion: Build? = null
         private set
 
-    var newestBuild: Build? = null
-        private set
-
     fun hasUpdate(): Boolean {
         try {
             val newestSemVersion = Semver(newestVersion?.tagName, Semver.SemverType.LOOSE)
 
             return if (LiquidBounce.IN_DEV) { // check if new build is newer than current build
-                val newestBuildDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestBuild?.date)
+                val newestBuildDate = ClientApi.getNewestBuildDate()
                 val currentBuildDate =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(gitInfo["git.commit.time"].toString())
 

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -34,10 +34,7 @@ object ClientUpdate {
         }
     }
 
-    var newestVersion: Version? = null
-        private set
-
-    var newestBuild: Build? = null
+    var newestVersion: Build? = null
         private set
 
     fun hasUpdate(): Boolean {
@@ -54,7 +51,7 @@ object ClientUpdate {
             val newestSemVersion = Semver(newestVersion.tagName, Semver.SemverType.LOOSE)
 
             val isNewer = if (LiquidBounce.IN_DEV) { // check if new build is newer than current build
-                val newestBuildDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestBuild.date)
+                val newestBuildDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestVersion.date)
                 val currentBuildDate =
                     SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(gitInfo["git.commit.time"].toString())
 
@@ -67,7 +64,7 @@ object ClientUpdate {
             }
 
             if (isNewer) {
-                newestBuild
+                newestVersion
             } else {
                 null
             }

--- a/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ClientUpdate.kt
@@ -5,6 +5,7 @@
  */
 package net.ccbluex.liquidbounce.api
 
+import com.vdurmont.semver4j.Semver
 import net.ccbluex.liquidbounce.LiquidBounce
 import net.ccbluex.liquidbounce.LiquidBounce.IN_DEV
 import net.ccbluex.liquidbounce.LiquidBounce.clientVersionNumber
@@ -36,7 +37,7 @@ object ClientUpdate {
     var newestVersion: Build? = null
         private set
 
-    fun hasUpdate(): Boolean {
+    /* fun hasUpdate(): Boolean {
         try {
             val newestVersion = newestVersion ?: return false
             val actualVersionNumber =
@@ -56,7 +57,43 @@ object ClientUpdate {
             LOGGER.error("Unable to check for update", e)
             return false
         }
-    }
+    } */
 
+    val update {
+        try {
+            /* val newestBuild = runCatching {
+                ClientApi.requestNewestBuildEndpoint(
+                    branch = LiquidBounce.clientBranch,
+                    prerelease = LiquidBounce.IN_DEV
+                )
+            }.onFailure { exception ->
+                logger.error("Unable to receive update information", exception)
+            }.getOrNull() ?: return@AsyncLazy null */
+
+            val newestSemVersion = Semver(newestBuild.tagName, Semver.SemverType.LOOSE)
+
+            val isNewer = if (LiquidBounce.IN_DEV) { // check if new build is newer than current build
+                val newestVersionDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(newestBuild.date)
+                val currentVersionDate =
+                    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ").parse(gitInfo["git.commit.time"].toString())
+
+                newestVersionDate.after(currentVersionDate)
+            } else {
+                // check if version number is higher than current version number (on release builds only!)
+                val clientSemVersion = Semver(LiquidBounce.clientVersionText, Semver.SemverType.LOOSE)
+
+                newestBuild.release && newestSemVersion.isGreaterThan(clientSemVersion)
+            }
+
+            if (isNewer) {
+                newestBuild
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            LOGGER.error("Failed to check for update", e)
+            return false
+        }
+    }
 }
 

--- a/src/main/java/net/ccbluex/liquidbounce/api/ResponseTypes.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ResponseTypes.kt
@@ -14,8 +14,6 @@ data class Build(
     val branch: String,
     @SerializedName("tag_name")
     val tagName: String,
-    @SerializedName("mc_version")
-    val mcVersion: String,
     val prerelease: Boolean,
     val date: String,
     val message: String,

--- a/src/main/java/net/ccbluex/liquidbounce/api/ResponseTypes.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/api/ResponseTypes.kt
@@ -12,11 +12,11 @@ data class Build(
     @SerializedName("commit_id")
     val commitId: String,
     val branch: String,
-    @SerializedName("lb_version")
-    val lbVersion: String,
+    @SerializedName("tag_name")
+    val tagName: String,
     @SerializedName("mc_version")
     val mcVersion: String,
-    val release: Boolean,
+    val prerelease: Boolean,
     val date: String,
     val message: String,
     val url: String

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/GuiMainMenu.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/GuiMainMenu.kt
@@ -108,7 +108,7 @@ class GuiMainMenu : AbstractScreen() {
     private fun showUpdatePopup() {
         val newestVersion = ClientUpdate.newestVersion ?: return
 
-        val isReleaseBuild = newestVersion.release
+        val isReleaseBuild = !newestVersion.prerelease
         val updateType = if (isReleaseBuild) "version" else "development build"
 
         val dateFormatter = SimpleDateFormat("EEEE, MMMM dd, yyyy, h a z", Locale.ENGLISH)
@@ -120,7 +120,7 @@ class GuiMainMenu : AbstractScreen() {
             message("""
                 §eA new $updateType of LibreBounce is available!
         
-                - ${if (isReleaseBuild) "§aVersion" else "§aBuild ID"}:§r ${if (isReleaseBuild) newestVersion.lbVersion else newestVersion.buildId}
+                - ${if (isReleaseBuild) "§aVersion" else "§aBuild ID"}:§r ${if (isReleaseBuild) newestVersion.tagName else newestVersion.buildId}
                 - §aBranch:§r ${newestVersion.branch}
                 - §aDate:§r $formattedNewestDate
         

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/GuiMainMenu.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/GuiMainMenu.kt
@@ -8,7 +8,7 @@ package net.ccbluex.liquidbounce.ui.client
 import net.ccbluex.liquidbounce.LiquidBounce.CLIENT_NAME
 import net.ccbluex.liquidbounce.LiquidBounce.clientVersionText
 import net.ccbluex.liquidbounce.api.ClientUpdate
-import net.ccbluex.liquidbounce.api.ClientUpdate.hasUpdate
+import net.ccbluex.liquidbounce.api.ClientUpdate.update
 import net.ccbluex.liquidbounce.file.FileManager
 import net.ccbluex.liquidbounce.file.FileManager.valuesConfig
 import net.ccbluex.liquidbounce.lang.translationMenu
@@ -51,7 +51,7 @@ class GuiMainMenu : AbstractScreen() {
             }
             when {
                 FileManager.firstStart -> showWelcomePopup()
-                hasUpdate() -> showUpdatePopup()
+                update -> showUpdatePopup()
             }
             popupOnce = true
         }
@@ -118,7 +118,7 @@ class GuiMainMenu : AbstractScreen() {
         popup = PopupScreen {
             title("§bNew Update Available!")
             message("""
-                §eA new $updateType of LiquidBounce is available!
+                §eA new $updateType of LibreBounce is available!
         
                 - ${if (isReleaseBuild) "§aVersion" else "§aBuild ID"}:§r ${if (isReleaseBuild) newestVersion.lbVersion else newestVersion.buildId}
                 - §aMinecraft Version:§r ${newestVersion.mcVersion}

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/GuiMainMenu.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/GuiMainMenu.kt
@@ -8,7 +8,7 @@ package net.ccbluex.liquidbounce.ui.client
 import net.ccbluex.liquidbounce.LiquidBounce.CLIENT_NAME
 import net.ccbluex.liquidbounce.LiquidBounce.clientVersionText
 import net.ccbluex.liquidbounce.api.ClientUpdate
-import net.ccbluex.liquidbounce.api.ClientUpdate.update
+import net.ccbluex.liquidbounce.api.ClientUpdate.hasUpdate
 import net.ccbluex.liquidbounce.file.FileManager
 import net.ccbluex.liquidbounce.file.FileManager.valuesConfig
 import net.ccbluex.liquidbounce.lang.translationMenu
@@ -51,7 +51,7 @@ class GuiMainMenu : AbstractScreen() {
             }
             when {
                 FileManager.firstStart -> showWelcomePopup()
-                update -> showUpdatePopup()
+                hasUpdate() -> showUpdatePopup()
             }
             popupOnce = true
         }
@@ -121,7 +121,6 @@ class GuiMainMenu : AbstractScreen() {
                 §eA new $updateType of LibreBounce is available!
         
                 - ${if (isReleaseBuild) "§aVersion" else "§aBuild ID"}:§r ${if (isReleaseBuild) newestVersion.lbVersion else newestVersion.buildId}
-                - §aMinecraft Version:§r ${newestVersion.mcVersion}
                 - §aBranch:§r ${newestVersion.branch}
                 - §aDate:§r $formattedNewestDate
         


### PR DESCRIPTION
This is one of the most annoying issues I've had, while making this fork. Hopefully, this pull request fixes that. Additionally, I'll bump the version to 0.2.0.