### PR TITLE
Build renaming from LiquidBounce to LibreBounce

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build
         run: ./gradlew build
       - name: Rename artifact
-        run: mv build/libs/liquidbounce-*.jar build/libs/LibreBounce.jar
+        run: mv build/libs/librebounce-*.jar build/libs/LibreBounce.jar
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.settings/
 /.gradle/
 /.kotlin/
+/.idea/

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx3g
 
 mod_version=0.1.0
 maven_group=net.ccbluex
-archives_base_name=liquidbounce
+archives_base_name=librebounce
 
 # Kotlin
 # https://kotlinlang.org/releases.html


### PR DESCRIPTION
This pull request changes the JAR artifact name from LiquidBounce to LibreBounce. I also remembered to change this on the GitHub Actions workflow.