### PR TITLE
Add space in window title between name and version

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/LiquidBounce.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/LiquidBounce.kt
@@ -88,7 +88,7 @@ object LiquidBounce {
      */
     const val IN_DEV = false
 
-    val clientTitle = CLIENT_NAME + clientVersionText + " " + clientCommit + " | " + MINECRAFT_VERSION + if (IN_DEV) " | DEVELOPMENT BUILD" else ""
+    val clientTitle = CLIENT_NAME + " " + clientVersionText + " " + clientCommit + " | " + MINECRAFT_VERSION + if (IN_DEV) " | DEVELOPMENT BUILD" else ""
 
     var isStarting = true
 


### PR DESCRIPTION
Fixes a typo in the window title to have a space between the client name and version.