### PR TITLE
Add miss-clicking for the ChestStealer module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Common Changelog](https://common-changelog.org), which i
 
 ## [Unreleased]
 
+### Added
+
+- Legit-like miss-clicking to ChestStealer ([#28](https://github.com/LibreBounce/LibreBounce/pull/28)) (thatonecoder)
+
 ## [0.4.0] - 2025-09-21
 
 ### Added
@@ -123,3 +127,4 @@ _Initial release, forked from LiquidBounce Legacy._
 [0.3.0]: https://github.com/LibreBounce/LibreBounce/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/LibreBounce/LibreBounce/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/LibreBounce/LibreBounce/releases/tag/v0.1.0
+

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoArmor.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoArmor.kt
@@ -55,8 +55,7 @@ object AutoArmor : Module("AutoArmor", Category.COMBAT) {
 
     private val hotbar by boolean("Hotbar", true)
 
-    // Sacrifices 1 tick speed for complete undetectability, needed to bypass Vulcan
-    private val delayedSlotSwitch by boolean("DelayedSlotSwitch", true) { hotbar }
+    private val hotbarSlotSwitchDelay by intRange("HotbarSlotSwitchDelay", 50..50, 0..1000) { hotbar }
 
     // Prevents AutoArmor from hotbar equipping while any screen is open
     private val notInContainers by boolean("NotInContainers", false) { hotbar }
@@ -127,9 +126,7 @@ object AutoArmor : Module("AutoArmor", Category.COMBAT) {
             // Schedule hotbar click
             nextTick(action = equippingAction)
 
-            if (delayedSlotSwitch) {
-                delay(delay.random().toLong())
-            }
+            delay(hotbarSlotSwitchDelay.random().toLong())
         }
 
         delay(delay.random().toLong())

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -52,12 +52,8 @@ import kotlin.math.sqrt
 
 object ChestStealer : Module("ChestStealer", Category.WORLD) {
 
-    // TODO: Make the ChestStealer occasionally miss
-    // It would need to underflick or (more rarely) overflick to items, and click in those miss-flicks
-    // Additionally, after consecutively picking up items adjacent to each other,
-    // there is a higher chance to miss, specifically underflicking (~2/3 and ~1/3 chance, respectively)
-    // After miss-clicking, it needs to do a short stop, and either pick up the item correctly, or miss again
-    // (~2/3 and ~1/3 chance, respectively)
+    // TODO: Make SmartOrder prioritize slightly farther but more essential items, e.g, armor
+    // instead of arrows
     private val smartDelay by boolean("SmartDelay", false)
     private val multiplier by intRange("DelayMultiplier", 120..140, 0..500) { smartDelay }
     private val smartOrder by boolean("SmartOrder", true) { smartDelay }
@@ -68,6 +64,8 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
     private val shortStopChance by int("ShortStopChance", 75, 0..100, suffix = "%") { simulateShortStop }
     private val shortStopLength by intRange("ShortStopLength", 350..650, 0..1000, suffix = "ms") { simulateShortStop }
 
+    // TODO: Make it more likely to happen over a longer distance, and the opposite, too
+    // Also add an option to not miss-click consecutively
     private val missClick by boolean("MissClick", false)
     private val missClickChance by int("MissClickChance", 75, 0..100, suffix = "%") { missClick }
     private val pauseAfterMissClick by intRange("PauseAfterMissClick", 350..650, 0..1000, suffix = "ms") { missClick }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -205,7 +205,7 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
 
                     if (itemStolenDebug) debug("item: ${stack.displayName.lowercase()} | slot: $slot | delay: ${stealingDelay}ms")
 
-                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick(screen, slot))
+                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick(screen, screen.inventorySlots.inventorySlots[slot]))
                         delay(pauseAfterMissClickLength.random().toLong())
 
                     // If target is sortable to a hotbar slot, steal and sort it at the same time, else shift + left-click

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -204,7 +204,7 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
 
                     if (itemStolenDebug) debug("item: ${stack.displayName.lowercase()} | slot: $slot | delay: ${stealingDelay}ms")
 
-                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick(screen))
+                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick(screen, slot))
                         delay(pauseAfterMissClickLength.random().toLong())
 
                     // If target is sortable to a hotbar slot, steal and sort it at the same time, else shift + left-click
@@ -369,18 +369,19 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
 
         return itemsToSteal
     }
-
-    private fun performMissClick(screen: GuiChest): Boolean {
-        val itemsInContainer = screen.getSlotsInContainer()
+ 
+    private fun performMissClick(screen: GuiChest, targetSlot: Slot): Boolean {
+        val itemsInContainer = screen.inventorySlots.inventorySlots
         val closestEmptySlot = itemsInContainer
-            .filter { it.itemStack.isEmpty }
-            .minByOrNull { slot.distance(it) } ?: return false
+            .filter { it.stack == null || it.stack.stackSize == 0 }
+            .minByOrNull { otherSlot ->
+                squaredDistanceOfSlots(targetSlot, otherSlot)
+            } ?: return false
 
-        val slotId = closestEmptySlot.slotNumber // Use the slot number directly
+        val slotId = closestEmptySlot.slotNumber
         clickNextTick(slotId, 0, 1)
         return true
     }
-
 
     private fun sortBasedOnOptimumPath(itemsToSteal: MutableList<ItemTakeRecord>) {
         for (i in itemsToSteal.indices) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -193,15 +193,12 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
                         return@scheduler
                     }
 
+                    hasTaken = true
+
                     if (missClick && nextInt(endExclusive = 100) < missClickChance) {
                         performMissClick(screen, screen.inventorySlots.inventorySlots[slot])
-                        chestStealerCurrentSlot = -1
-                        chestStealerLastSlot = -1
                         delay(pauseAfterMissClickLength.toLong())
-                        return
                     }
-
-                    hasTaken = true
 
                     // Set current slot being stolen for highlighting
                     chestStealerCurrentSlot = slot
@@ -390,6 +387,7 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
         clickNextTick(slotId, 0, 1)
         pauseAfterMissClickLength = pauseAfterMissClick.random()
         if (itemStolenDebug) debug("Miss-clicked on slot $slotId. Delay until next click: ${pauseAfterMissClickLength}ms")
+        chestStealerCurrentSlot = slotId
     }
 
     private fun sortBasedOnOptimumPath(itemsToSteal: MutableList<ItemTakeRecord>) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -197,6 +197,7 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
                         performMissClick(screen, screen.inventorySlots.inventorySlots[slot])
                         chestStealerCurrentSlot = -1
                         chestStealerLastSlot = -1
+                        delay(pauseAfterMissClickLength.toLong())
                         return
                     }
 
@@ -388,7 +389,6 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
         val slotId = closestEmptySlot.slotNumber
         clickNextTick(slotId, 0, 1)
         pauseAfterMissClickLength = pauseAfterMissClick.random()
-        delay(pauseAfterMissClickLength.toLong())
         if (itemStolenDebug) debug("Miss-clicked on slot $slotId. Delay until next click: ${pauseAfterMissClickLength}ms")
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -376,7 +376,7 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
         return itemsToSteal
     }
  
-    private fun performMissClick(screen: GuiChest, targetSlot: Slot)Pp {
+    private fun performMissClick(screen: GuiChest, targetSlot: Slot) {
         if (missClick && nextInt(endExclusive = 100) < missClickChance)
             val itemsInContainer = screen.inventorySlots.inventorySlots
             val closestEmptySlot = itemsInContainer

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -70,7 +70,7 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
 
     private val missClick by boolean("MissClick", false)
     private val missClickChance by int("MissClickChance", 75, 0..100, suffix = "%") { missClick }
-    private val pauseAfterMissClickLength by intRange("PauseAfterMissClickLength", 350..650, 0..1000, suffix = "ms") { missClick }
+    private val pauseAfterMissClick by intRange("PauseAfterMissClick", 350..650, 0..1000, suffix = "ms") { missClick }
 
     private val delay by intRange("Delay", 50..50, 0..500, suffix = "ms")
     private val startDelay by intRange("StartDelay", 50..100, 0..500, suffix = "ms")
@@ -113,6 +113,8 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
     private var receivedId: Int? = null
 
     private var stacks = emptyList<ItemStack?>()
+
+    private var pauseAfterMissClickLength = pauseAfterMissClick.random()
 
     var isCustomGUI = false
 
@@ -203,10 +205,12 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
                         delay.random()
                     }
 
-                    if (itemStolenDebug) debug("item: ${stack.displayName.lowercase()} | slot: $slot | delay: ${stealingDelay}ms")
+                    if (itemStolenDebug) debug("Stole ${stack.displayName.lowercase()} on slot ${slot}. Delay: ${stealingDelay}ms")
 
-                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick(screen, screen.inventorySlots.inventorySlots[slot]))
-                        delay(pauseAfterMissClickLength.random().toLong())
+                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick(screen, screen.inventorySlots.inventorySlots[slot])) {
+                        pauseAfterMissClickLength = pauseAfterMissClick.random()
+                        delay(pauseAfterMissClickLength.toLong())
+                    }
 
                     // If target is sortable to a hotbar slot, steal and sort it at the same time, else shift + left-click
                     clickNextTick(slot, sortableTo ?: 0, if (sortableTo != null) 2 else 1) {
@@ -381,6 +385,7 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
 
         val slotId = closestEmptySlot.slotNumber
         clickNextTick(slotId, 0, 1)
+        if (itemStolenDebug) debug("Miss-clicked on slot $slotId. Delay until next click: ${pauseAfterMissClickLength}ms")
         return true
     }
 

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -193,6 +193,13 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
                         return@scheduler
                     }
 
+                    if (missClick && nextInt(endExclusive = 100) < missClickChance) {
+                        performMissClick(screen, screen.inventorySlots.inventorySlots[slot])
+                        chestStealerCurrentSlot = -1
+                        chestStealerLastSlot = -1
+                        return
+                    }
+
                     hasTaken = true
 
                     // Set current slot being stolen for highlighting
@@ -206,12 +213,6 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
                     }
 
                     if (itemStolenDebug) debug("Stole ${stack.displayName.lowercase()} on slot ${slot}. Delay: ${stealingDelay}ms")
-
-                    if (missClick && nextInt(endExclusive = 100) < missClickChance) && performMissClick(screen, screen.inventorySlots.inventorySlots[slot])) {
-                        pauseAfterMissClickLength = pauseAfterMissClick.random()
-                        delay(pauseAfterMissClickLength.toLong())
-                    }
-                    performMissClick(screen, screen.inventorySlots.inventorySlots[slot])
 
                     // If target is sortable to a hotbar slot, steal and sort it at the same time, else shift + left-click
                     clickNextTick(slot, sortableTo ?: 0, if (sortableTo != null) 2 else 1) {
@@ -377,20 +378,18 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
     }
  
     private fun performMissClick(screen: GuiChest, targetSlot: Slot) {
-        if (missClick && nextInt(endExclusive = 100) < missClickChance)
-            val itemsInContainer = screen.inventorySlots.inventorySlots
-            val closestEmptySlot = itemsInContainer
-                .filter { it.stack == null || it.stack.stackSize == 0 }
-                .minByOrNull { otherSlot ->
-                    squaredDistanceOfSlots(targetSlot.slotNumber, otherSlot.slotNumber)
-                } ?: return
+        val itemsInContainer = screen.inventorySlots.inventorySlots
+        val closestEmptySlot = itemsInContainer
+            .filter { it.stack == null || it.stack.stackSize == 0 }
+            .minByOrNull { otherSlot ->
+                squaredDistanceOfSlots(targetSlot.slotNumber, otherSlot.slotNumber)
+            } ?: return
 
-            val slotId = closestEmptySlot.slotNumber
-            clickNextTick(slotId, 0, 1)
-            pauseAfterMissClickLength = pauseAfterMissClick.random()
-            delay(pauseAfterMissClickLength.toLong())
-            if (itemStolenDebug) debug("Miss-clicked on slot $slotId. Delay until next click: ${pauseAfterMissClickLength}ms")
-        }
+        val slotId = closestEmptySlot.slotNumber
+        clickNextTick(slotId, 0, 1)
+        pauseAfterMissClickLength = pauseAfterMissClick.random()
+        delay(pauseAfterMissClickLength.toLong())
+        if (itemStolenDebug) debug("Miss-clicked on slot $slotId. Delay until next click: ${pauseAfterMissClickLength}ms")
     }
 
     private fun sortBasedOnOptimumPath(itemsToSteal: MutableList<ItemTakeRecord>) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -207,10 +207,11 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
 
                     if (itemStolenDebug) debug("Stole ${stack.displayName.lowercase()} on slot ${slot}. Delay: ${stealingDelay}ms")
 
-                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick(screen, screen.inventorySlots.inventorySlots[slot])) {
+                    if (missClick && nextInt(endExclusive = 100) < missClickChance) && performMissClick(screen, screen.inventorySlots.inventorySlots[slot])) {
                         pauseAfterMissClickLength = pauseAfterMissClick.random()
                         delay(pauseAfterMissClickLength.toLong())
                     }
+                    performMissClick(screen, screen.inventorySlots.inventorySlots[slot])
 
                     // If target is sortable to a hotbar slot, steal and sort it at the same time, else shift + left-click
                     clickNextTick(slot, sortableTo ?: 0, if (sortableTo != null) 2 else 1) {
@@ -375,18 +376,21 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
         return itemsToSteal
     }
  
-    private fun performMissClick(screen: GuiChest, targetSlot: Slot): Boolean {
-        val itemsInContainer = screen.inventorySlots.inventorySlots
-        val closestEmptySlot = itemsInContainer
-            .filter { it.stack == null || it.stack.stackSize == 0 }
-            .minByOrNull { otherSlot ->
-                squaredDistanceOfSlots(targetSlot.slotNumber, otherSlot.slotNumber)
-            } ?: return false
+    private fun performMissClick(screen: GuiChest, targetSlot: Slot)Pp {
+        if (missClick && nextInt(endExclusive = 100) < missClickChance)
+            val itemsInContainer = screen.inventorySlots.inventorySlots
+            val closestEmptySlot = itemsInContainer
+                .filter { it.stack == null || it.stack.stackSize == 0 }
+                .minByOrNull { otherSlot ->
+                    squaredDistanceOfSlots(targetSlot.slotNumber, otherSlot.slotNumber)
+                } ?: return
 
-        val slotId = closestEmptySlot.slotNumber
-        clickNextTick(slotId, 0, 1)
-        if (itemStolenDebug) debug("Miss-clicked on slot $slotId. Delay until next click: ${pauseAfterMissClickLength}ms")
-        return true
+            val slotId = closestEmptySlot.slotNumber
+            clickNextTick(slotId, 0, 1)
+            pauseAfterMissClickLength = pauseAfterMissClick.random()
+            delay(pauseAfterMissClickLength.toLong())
+            if (itemStolenDebug) debug("Miss-clicked on slot $slotId. Delay until next click: ${pauseAfterMissClickLength}ms")
+        }
     }
 
     private fun sortBasedOnOptimumPath(itemsToSteal: MutableList<ItemTakeRecord>) {

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -204,9 +204,8 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
 
                     if (itemStolenDebug) debug("item: ${stack.displayName.lowercase()} | slot: $slot | delay: ${stealingDelay}ms")
 
-                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick()) {
+                    if (missClick && nextInt(endExclusive = 100) < missClickChance && performMissClick(screen))
                         delay(pauseAfterMissClickLength.random().toLong())
-                    }
 
                     // If target is sortable to a hotbar slot, steal and sort it at the same time, else shift + left-click
                     clickNextTick(slot, sortableTo ?: 0, if (sortableTo != null) 2 else 1) {
@@ -371,17 +370,13 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
         return itemsToSteal
     }
 
-    private fun performMissClick(): Boolean {
-        if (screen !is GuiChest)
-            return
-
+    private fun performMissClick(screen: GuiChest): Boolean {
         val itemsInContainer = screen.getSlotsInContainer()
-        // Find the closest item to the slot which is empty
         val closestEmptySlot = itemsInContainer
             .filter { it.itemStack.isEmpty }
             .minByOrNull { slot.distance(it) } ?: return false
 
-        val slotId = closestEmptySlot.getIdForServer(screen)
+        val slotId = closestEmptySlot.slotNumber // Use the slot number directly
         clickNextTick(slotId, 0, 1)
         return true
     }

--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/world/ChestStealer.kt
@@ -38,6 +38,7 @@ import net.ccbluex.liquidbounce.utils.timing.TickedActions.nextTick
 import net.ccbluex.liquidbounce.utils.timing.TimeUtils.randomDelay
 import net.minecraft.client.gui.ScaledResolution
 import net.minecraft.client.gui.inventory.GuiChest
+import net.minecraft.inventory.Slot
 import net.minecraft.entity.EntityLiving.getArmorPosition
 import net.minecraft.init.Blocks.chest
 import net.minecraft.item.ItemArmor
@@ -375,7 +376,7 @@ object ChestStealer : Module("ChestStealer", Category.WORLD) {
         val closestEmptySlot = itemsInContainer
             .filter { it.stack == null || it.stack.stackSize == 0 }
             .minByOrNull { otherSlot ->
-                squaredDistanceOfSlots(targetSlot, otherSlot)
+                squaredDistanceOfSlots(targetSlot.slotNumber, otherSlot.slotNumber)
             } ?: return false
 
         val slotId = closestEmptySlot.slotNumber

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/element/elements/Arraylist.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/element/elements/Arraylist.kt
@@ -193,7 +193,7 @@ class Arraylist(
         }
 
         var moduleTag = if (!module.tag.isNullOrEmpty()) {
-            if (spacedTags) module.tag?.addSpaces() else module.tag
+            if (spacedTags) module.tag?.addSpaces() ?: "" else module.tag ?: ""
         } else {
             ""
         }

--- a/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/element/elements/TabGUI.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/ui/client/hud/element/elements/TabGUI.kt
@@ -348,8 +348,8 @@ class TabGUI(x: Double = 16.0, y: Double = 43.0) : Element("TabGUI", x = x, y = 
         }
     }
 
-    fun getDisplayName(module: Module) = {
-        when (moduleCase) {
+    fun getDisplayName(module: Module): String {
+        return when (moduleCase) {
             "Uppercase" -> module.getName().uppercase()
             "Lowercase" -> module.getName().lowercase()
             else -> module.getName()


### PR DESCRIPTION
These miss-clicks happen in spots adjacent to the next item stolen, emulating legit behaviour.